### PR TITLE
fix: small typo in the destructors example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -321,7 +321,7 @@ nothing.
    }
    int main( int argc, char **argv )
    {
-       Foo foo();
+       Foo foo;
        return 0;
    }
 


### PR DESCRIPTION
Fix for a small typo in the `Destructors` example.